### PR TITLE
Fix broken links and buddy runner navigation

### DIFF
--- a/ai-companions.html
+++ b/ai-companions.html
@@ -57,7 +57,10 @@
                     <li class="nav-item"><a href="index.html#collection" class="nav-link">COLLECTION</a></li>
                     <li class="nav-item"><a href="index.html#roadmap" class="nav-link">ROADMAP</a></li>
                     <li class="nav-item"><a href="index.html#community" class="nav-link">COMMUNITY</a></li>
-                    <li class="nav-item"><a href="buddy-runner.html" class="nav-link">BUDDY RUNNER</a></li>
+                    <li class="nav-item"><a href="https://buddyrunner.fun" target="_blank" class="nav-link external-link">
+                        BUDDY RUNNER
+                        <i class="fas fa-external-link-alt"></i>
+                    </a></li>
                     <li class="nav-item"><a href="https://t.me/mega_buddies_wl_checker_bot" target="_blank" class="nav-link external-link">
                         WL CHECKER
                         <i class="fas fa-external-link-alt"></i>
@@ -359,7 +362,7 @@
                         <li class="footer-nav-link"><a href="telegram-bots.html">Telegram Bots</a></li>
                         <li class="footer-nav-link"><a href="zealy-quests.html">Zealy Quests</a></li>
                         <li class="footer-nav-link"><a href="ai-companions.html">AI Companions</a></li>
-                        <li class="footer-nav-link"><a href="buddy-runner.html">Buddy Runner</a></li>
+                        <li class="footer-nav-link"><a href="https://buddyrunner.fun" target="_blank">Buddy Runner</a></li>
                         <li class="footer-nav-link"><a href="leaderboard.html">Leaderboard</a></li>
                     </ul>
                 </div>

--- a/index.html
+++ b/index.html
@@ -78,7 +78,10 @@
                     <li class="nav-item"><a href="#collection" class="nav-link">COLLECTION</a></li>
                     <li class="nav-item"><a href="#roadmap" class="nav-link">ROADMAP</a></li>
                     <li class="nav-item"><a href="#community" class="nav-link">COMMUNITY</a></li>
-                    <li class="nav-item"><a href="buddy-runner.html" class="nav-link">BUDDY RUNNER</a></li>
+                    <li class="nav-item"><a href="https://buddyrunner.fun" target="_blank" class="nav-link external-link">
+                        BUDDY RUNNER
+                        <i class="fas fa-external-link-alt"></i>
+                    </a></li>
                     <li class="nav-item"><a href="https://t.me/mega_buddies_wl_checker_bot" target="_blank" class="nav-link external-link">
                         WL CHECKER
                         <i class="fas fa-external-link-alt"></i>

--- a/js/main.js
+++ b/js/main.js
@@ -196,22 +196,27 @@ document.addEventListener('DOMContentLoaded', function() {
     
     navLinks.forEach(link => {
         link.addEventListener('click', function(e) {
-            e.preventDefault();
+            const href = this.getAttribute('href');
             
-            const targetId = this.getAttribute('href').substring(1);
-            const targetSection = document.getElementById(targetId);
-            
-            if (targetSection) {
-                // Отступ с учетом мобильной версии
-                const offset = isMobile() ? 70 : 100;
+            // Обрабатываем только внутренние ссылки (начинающиеся с #)
+            if (href && href.startsWith('#')) {
+                e.preventDefault();
                 
-                window.scrollTo({
-                    top: targetSection.offsetTop - offset,
-                    behavior: 'smooth'
-                });
+                const targetId = href.substring(1);
+                const targetSection = document.getElementById(targetId);
+                
+                if (targetSection) {
+                    // Отступ с учетом мобильной версии
+                    const offset = isMobile() ? 70 : 100;
+                    
+                    window.scrollTo({
+                        top: targetSection.offsetTop - offset,
+                        behavior: 'smooth'
+                    });
+                }
             }
             
-            // Закрываем мобильное меню при клике на ссылку
+            // Закрываем мобильное меню при клике на любую ссылку
             if (isMobile() && navList.classList.contains('active')) {
                 mobileMenuToggle.classList.remove('active');
                 navList.classList.remove('active');

--- a/mobile.html
+++ b/mobile.html
@@ -77,7 +77,10 @@
                     <li class="nav-item"><a href="#collection" class="nav-link">COLLECTION</a></li>
                     <li class="nav-item"><a href="#roadmap" class="nav-link">ROADMAP</a></li>
                     <li class="nav-item"><a href="#community" class="nav-link">COMMUNITY</a></li>
-                    <li class="nav-item"><a href="buddy-runner.html" class="nav-link">BUDDY RUNNER</a></li>
+                    <li class="nav-item"><a href="https://buddyrunner.fun" target="_blank" class="nav-link external-link">
+                        BUDDY RUNNER
+                        <i class="fas fa-external-link-alt"></i>
+                    </a></li>
                     <li class="nav-item"><a href="https://t.me/mega_buddies_wl_checker_bot" target="_blank" class="nav-link external-link">
                         WL CHECKER
                         <i class="fas fa-external-link-alt"></i>

--- a/telegram-bots.html
+++ b/telegram-bots.html
@@ -57,7 +57,10 @@
                     <li class="nav-item"><a href="index.html#collection" class="nav-link">COLLECTION</a></li>
                     <li class="nav-item"><a href="index.html#roadmap" class="nav-link">ROADMAP</a></li>
                     <li class="nav-item"><a href="index.html#community" class="nav-link">COMMUNITY</a></li>
-                    <li class="nav-item"><a href="buddy-runner.html" class="nav-link">BUDDY RUNNER</a></li>
+                    <li class="nav-item"><a href="https://buddyrunner.fun" target="_blank" class="nav-link external-link">
+                        BUDDY RUNNER
+                        <i class="fas fa-external-link-alt"></i>
+                    </a></li>
                     <li class="nav-item"><a href="https://t.me/mega_buddies_wl_checker_bot" target="_blank" class="nav-link external-link">
                         WL CHECKER
                         <i class="fas fa-external-link-alt"></i>
@@ -362,7 +365,7 @@
                         <li class="footer-nav-link"><a href="telegram-bots.html">Telegram Bots</a></li>
                         <li class="footer-nav-link"><a href="zealy-quests.html">Zealy Quests</a></li>
                         <li class="footer-nav-link"><a href="ai-companions.html">AI Companions</a></li>
-                        <li class="footer-nav-link"><a href="buddy-runner.html">Buddy Runner</a></li>
+                        <li class="footer-nav-link"><a href="https://buddyrunner.fun" target="_blank">Buddy Runner</a></li>
                         <li class="footer-nav-link"><a href="leaderboard.html">Leaderboard</a></li>
                     </ul>
                 </div>


### PR DESCRIPTION
Fix external navigation links (WL CHECKER, DOCS, BUDDY RUNNER) by correcting JavaScript behavior and updating the BUDDY RUNNER URL.

The `js/main.js` script was incorrectly calling `e.preventDefault()` for all `.nav-link` elements, which prevented external links from working. This change modifies the script to only prevent default behavior for internal anchor links (starting with `#`), allowing external links to function correctly. Additionally, the "BUDDY RUNNER" link was updated from a non-existent local file to its correct external URL and given consistent external link styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-943eba9a-a491-4d41-8733-b975deb6195f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-943eba9a-a491-4d41-8733-b975deb6195f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

