### PR TITLE
Add avon card to mega mafia

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,10 +359,17 @@
                     <div class="twitter-embed-container">
                         <blockquote class="twitter-tweet" data-theme="dark"><p lang="en" dir="ltr">GBuddy! <br><br>We're excited to announce another partnership within the <a href="https://twitter.com/0xMegaMafia?ref_src=twsrc%5Etfw">@0xMegaMafia</a> family <br><br>This time with best real-time game ever - <a href="https://twitter.com/Showdown_TCG?ref_src=twsrc%5Etfw">@Showdown_TCG</a> 🥳<br><br>To celebrate, join us for a special Buddy Night X Showdown this Saturday (30/08) at 6 PM UTC. Core team member <a href="https://twitter.com/OndrejStrasky?ref_src=twsrc%5Etfw">@OndrejStrasky</a> will… <a href="https://t.co/SGjNtOk15H">pic.twitter.com/SGjNtOk15H</a></p>&mdash; Mega Buddies 🐰 (@mega_buddies) <a href="https://twitter.com/mega_buddies/status/1961155823717203989?ref_src=twsrc%5Etfw">August 28, 2025</a></blockquote>
                     </div>
-                    
+                </div>
 
+                <div class="partnership-card neon-glow" data-family="megamafia">
+                    <div class="partnership-badge megamafia">MEGAMAFIA</div>
+                    <h3>Avon</h3>
+                    <p class="partnership-description">A real-time lending market on MegaETH stack. Experience the future of decentralized finance with instant lending and borrowing capabilities.</p>
                     
-
+                    <!-- Twitter Embed -->
+                    <div class="twitter-embed-container">
+                        <blockquote class="twitter-tweet" data-theme="dark"><p lang="en" dir="ltr">Testnet tickets, Sunday edition <br><br>Buddy giving away closed 5 testnet access codes for Avon — a project accelerated by <a href="https://twitter.com/0xMegaMafia?ref_src=twsrc%5Etfw">@0xMegaMafia</a> and building on the MegaETH stack.<br><br>To enter:<br>1. Follow <a href="https://twitter.com/mega_buddies?ref_src=twsrc%5Etfw">@mega_buddies</a>, <a href="https://twitter.com/avon_xyz?ref_src=twsrc%5Etfw">@avon_xyz</a>, and <a href="https://twitter.com/im0xPrince?ref_src=twsrc%5Etfw">@im0xPrince</a><br>2. Like + QT this tweet with &quot;why YOU need a code&quot;.…</p>&mdash; Mega Buddies 🐰 (@mega_buddies) <a href="https://twitter.com/mega_buddies/status/1929189891578995066?ref_src=twsrc%5Etfw">June 1, 2025</a></blockquote>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Add Avon partnership card to the MegaMafia section, displaying it alongside Showdown as a real-time lending market.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f5c30b6-901c-4c1f-a462-5abd20520a4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f5c30b6-901c-4c1f-a462-5abd20520a4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

