### PR TITLE
Fix mobile section order and twitter preview

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -195,8 +195,8 @@
   
   /* Исправление позиции Twitter embed */
   .twitter-embed-container {
-    margin-top: 15px !important;
-    padding-top: 10px !important;
+    margin-top: 5px !important;
+    padding-top: 0px !important;
     width: 100% !important;
     overflow: visible !important;
     position: relative !important;


### PR DESCRIPTION
Reduced excessive top spacing for Twitter embed containers in mobile view to fix the large gap between project descriptions and Twitter previews.

---
<a href="https://cursor.com/background-agent?bcId=bc-a4541586-dc55-4f2b-9129-cfed5cb0654f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a4541586-dc55-4f2b-9129-cfed5cb0654f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

