### PR TITLE
Fix mobile ecosystem navigation and planned feature indicator

### DIFF
--- a/ai-companions.html
+++ b/ai-companions.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="mobile">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/css/style.css
+++ b/css/style.css
@@ -4043,3 +4043,66 @@ body {
         padding: 10px 15px;
     }
 }
+
+/* Planned/Disabled ecosystem card styles */
+.ecosystem-card.planned {
+    opacity: 0.6;
+    filter: grayscale(0.7);
+}
+
+.ecosystem-card.planned:hover {
+    transform: none;
+    border-color: var(--accent-color);
+    box-shadow: none;
+}
+
+.ecosystem-card.planned::before {
+    display: none;
+}
+
+.ecosystem-card.planned .ecosystem-icon {
+    background: linear-gradient(45deg, #666, #888);
+    opacity: 0.7;
+}
+
+.ecosystem-card.planned h3 {
+    color: #888;
+}
+
+.ecosystem-card.planned p {
+    opacity: 0.6;
+}
+
+.planned-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 25px;
+    background: rgba(100, 100, 100, 0.3);
+    color: rgba(255, 255, 255, 0.5);
+    border-radius: 5px;
+    font-family: var(--font-display);
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    border: 1px solid rgba(100, 100, 100, 0.5);
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+.planned-btn i {
+    font-size: 14px;
+}
+
+/* Dropdown planned styles */
+.dropdown-link.planned {
+    opacity: 0.5;
+    color: #888 !important;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+.dropdown-link.planned:hover {
+    background: none !important;
+    color: #888 !important;
+}

--- a/index.html
+++ b/index.html
@@ -85,10 +85,10 @@
                                 <span>AI Companions</span>
                             </a></li>
 
-                            <li><a href="leaderboard.html" class="dropdown-link">
+                            <li><span class="dropdown-link planned">
                                 <i class="fas fa-medal"></i>
-                                <span>Leaderboard</span>
-                            </a></li>
+                                <span>Leaderboard (Planned)</span>
+                            </span></li>
                         </ul>
                     </li>
                     <li class="nav-item"><a href="#partnerships" class="nav-link">PARTNERSHIPS</a></li>
@@ -286,7 +286,7 @@
                 </div>
                 
 
-                <div class="ecosystem-card neon-glow" data-feature="leaderboard">
+                <div class="ecosystem-card neon-glow planned" data-feature="leaderboard">
                     <div class="ecosystem-icon">
                         <i class="fas fa-medal"></i>
                     </div>
@@ -297,10 +297,10 @@
                         <span class="feature-tag">Achievement Tracking</span>
                         <span class="feature-tag">Real-time Updates</span>
                     </div>
-                    <a href="leaderboard.html" class="ecosystem-btn neon-button">
-                        VIEW RANKINGS
-                        <i class="fas fa-arrow-right"></i>
-                    </a>
+                    <div class="ecosystem-btn planned-btn">
+                        PLANNED
+                        <i class="fas fa-clock"></i>
+                    </div>
                 </div>
                 
                 <div class="ecosystem-card neon-glow" data-feature="buddy-runner">

--- a/js/device-detector.js
+++ b/js/device-detector.js
@@ -24,9 +24,22 @@
                window.location.pathname.lastIndexOf('/') === window.location.pathname.length - 1;
     }
 
+    // Определяем, открыта ли страница экосистемы (telegram-bots, ai-companions, etc.)
+    function isOnEcosystemPage() {
+        return window.location.pathname.indexOf('telegram-bots.html') !== -1 ||
+               window.location.pathname.indexOf('ai-companions.html') !== -1 ||
+               window.location.pathname.indexOf('zealy-quests.html') !== -1 ||
+               window.location.pathname.indexOf('leaderboard.html') !== -1;
+    }
+
     // Функция переадресации
     function redirectIfNeeded() {
         var isMobile = isMobileDevice();
+        
+        // Не переадресовываем, если пользователь на странице экосистемы
+        if (isOnEcosystemPage()) {
+            return;
+        }
         
         // Если устройство мобильное, но пользователь не на мобильной версии
         if (isMobile && !isOnMobilePage()) {

--- a/mobile.html
+++ b/mobile.html
@@ -70,10 +70,10 @@
                                 <span>AI Companions</span>
                             </a></li>
 
-                            <li><a href="leaderboard.html" class="dropdown-link">
+                            <li><span class="dropdown-link planned">
                                 <i class="fas fa-medal"></i>
-                                <span>Leaderboard</span>
-                            </a></li>
+                                <span>Leaderboard (Planned)</span>
+                            </span></li>
                         </ul>
                     </li>
                     <li class="nav-item"><a href="#roadmap" class="nav-link">ROADMAP</a></li>
@@ -328,7 +328,7 @@
                     </a>
                 </div>
 
-                <div class="ecosystem-card neon-glow" data-feature="leaderboard">
+                <div class="ecosystem-card neon-glow planned" data-feature="leaderboard">
                     <div class="ecosystem-icon">
                         <i class="fas fa-medal"></i>
                     </div>
@@ -339,10 +339,10 @@
                         <span class="feature-tag">Achievement Tracking</span>
                         <span class="feature-tag">Real-time Updates</span>
                     </div>
-                    <a href="leaderboard.html" class="ecosystem-btn neon-button">
-                        VIEW RANKINGS
-                        <i class="fas fa-arrow-right"></i>
-                    </a>
+                    <div class="ecosystem-btn planned-btn">
+                        PLANNED
+                        <i class="fas fa-clock"></i>
+                    </div>
                 </div>
             </div>
         </div>

--- a/telegram-bots.html
+++ b/telegram-bots.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="mobile">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
Prevent mobile redirection from ecosystem subpages and visually mark Quacks Leaderboard as 'Planned'.

The `device-detector.js` script was causing an infinite redirect loop for mobile users attempting to access ecosystem subpages (like Telegram Bots or AI Companions) because it would always redirect to `mobile.html` if the current page wasn't `mobile.html` and the device was mobile. The fix introduces a check to prevent redirection on these specific subpages and ensures they are correctly identified as mobile-friendly by adding the `mobile` class to their root `<html>` element.

---
<a href="https://cursor.com/background-agent?bcId=bc-29f2d66a-5add-4fe9-868e-59334d2caefb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-29f2d66a-5add-4fe9-868e-59334d2caefb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

