### PR TITLE
Investigate desktop card cutoff on hover

### DIFF
--- a/css/critical-scroll-fix.css
+++ b/css/critical-scroll-fix.css
@@ -15,7 +15,6 @@
     .partnerships-grid,
     .partnership-card,
     .ecosystem-grid,
-    .ecosystem-card,
     .community-content,
     .twitter-feed,
     .telegram-feed {
@@ -27,6 +26,11 @@
         height: auto !important;
         max-height: none !important;
         min-height: auto !important;
+    }
+
+    /* Позволяем ecosystem-card выходить за границы для hover эффекта */
+    .ecosystem-card {
+        overflow: visible !important;
     }
 
     /* Скрытие webkit скроллбаров */
@@ -42,7 +46,6 @@
     .partnerships-grid::-webkit-scrollbar,
     .partnership-card::-webkit-scrollbar,
     .ecosystem-grid::-webkit-scrollbar,
-    .ecosystem-card::-webkit-scrollbar,
     .community-content::-webkit-scrollbar,
     .twitter-feed::-webkit-scrollbar,
     .telegram-feed::-webkit-scrollbar,

--- a/css/scroll-fix.css
+++ b/css/scroll-fix.css
@@ -12,7 +12,6 @@
     html:not(.mobile) .partnerships-grid,
     html:not(.mobile) .partnership-card,
     html:not(.mobile) .ecosystem-grid,
-    html:not(.mobile) .ecosystem-card,
     html:not(.mobile) .community-content,
     html:not(.mobile) .twitter-feed,
     html:not(.mobile) .telegram-feed {
@@ -22,6 +21,11 @@
         scrollbar-width: none !important;
         -ms-overflow-style: none !important;
         -webkit-overflow-scrolling: auto !important;
+    }
+
+    /* Позволяем ecosystem-card выходить за границы для hover эффекта */
+    html:not(.mobile) .ecosystem-card {
+        overflow: visible !important;
     }
 
     /* Правила для элементов, где необходима фиксированная высота */
@@ -40,7 +44,6 @@
     html:not(.mobile) .partnerships-grid::-webkit-scrollbar,
     html:not(.mobile) .partnership-card::-webkit-scrollbar,
     html:not(.mobile) .ecosystem-grid::-webkit-scrollbar,
-    html:not(.mobile) .ecosystem-card::-webkit-scrollbar,
     html:not(.mobile) .community-content::-webkit-scrollbar,
     html:not(.mobile) .twitter-feed::-webkit-scrollbar,
     html:not(.mobile) .telegram-feed::-webkit-scrollbar {
@@ -92,7 +95,6 @@
     #partnerships .partnerships-grid,
     #partnerships .partnership-card,
     #ecosystem .ecosystem-grid,
-    #ecosystem .ecosystem-card,
     #community .community-content,
     #community .twitter-feed,
     #community .telegram-feed {
@@ -122,7 +124,6 @@
     html:not(.mobile) .partnerships-grid,
     html:not(.mobile) .partnership-card,
     html:not(.mobile) .ecosystem-grid,
-    html:not(.mobile) .ecosystem-card,
     html:not(.mobile) .community-content,
     html:not(.mobile) .twitter-feed,
     html:not(.mobile) .telegram-feed {

--- a/css/style.css
+++ b/css/style.css
@@ -2434,6 +2434,7 @@ body {
     grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
     gap: 30px;
     margin-top: 40px;
+    padding-top: 15px; /* Добавляем отступ сверху для hover эффекта */
 }
 
 .ecosystem-card {


### PR DESCRIPTION
Fixes ecosystem cards being clipped on hover by adjusting overflow properties and adding top padding.

The ecosystem cards were clipped because their hover effect (`transform: translateY(-5px)`) caused them to move outside their parent containers, which had `overflow: hidden`. This PR resolves the conflict by setting `overflow: visible` for the cards and adding `padding-top` to the grid container to provide the necessary space.

---
<a href="https://cursor.com/background-agent?bcId=bc-7525b51d-9588-4efb-b1d1-d5f1705eb88f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7525b51d-9588-4efb-b1d1-d5f1705eb88f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

