### PR TITLE
Increase card hover area upwards

### DIFF
--- a/css/critical-scroll-fix.css
+++ b/css/critical-scroll-fix.css
@@ -14,7 +14,6 @@
     .terminal-container,
     .partnerships-grid,
     .partnership-card,
-    .ecosystem-grid,
     .ecosystem-card,
     .community-content,
     .twitter-feed,
@@ -27,6 +26,13 @@
         height: auto !important;
         max-height: none !important;
         min-height: auto !important;
+    }
+    
+    /* Allow ecosystem grid to have visible overflow for hover effects */
+    .ecosystem-grid {
+        overflow: visible !important;
+        overflow-x: visible !important;
+        overflow-y: visible !important;
     }
 
     /* Скрытие webkit скроллбаров */
@@ -41,7 +47,6 @@
     .terminal-container::-webkit-scrollbar,
     .partnerships-grid::-webkit-scrollbar,
     .partnership-card::-webkit-scrollbar,
-    .ecosystem-grid::-webkit-scrollbar,
     .ecosystem-card::-webkit-scrollbar,
     .community-content::-webkit-scrollbar,
     .twitter-feed::-webkit-scrollbar,

--- a/css/critical-scroll-fix.css
+++ b/css/critical-scroll-fix.css
@@ -12,7 +12,6 @@
     .about-content,
     .terminal-content,
     .terminal-container,
-    .partnerships-grid,
     .partnership-card,
     .ecosystem-card,
     .community-content,
@@ -34,6 +33,13 @@
         overflow-x: visible !important;
         overflow-y: visible !important;
     }
+    
+    /* Allow partnerships grid to have visible overflow for hover effects */
+    .partnerships-grid {
+        overflow: visible !important;
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+    }
 
     /* Скрытие webkit скроллбаров */
     #about::-webkit-scrollbar,
@@ -45,7 +51,6 @@
     .about-content::-webkit-scrollbar,
     .terminal-content::-webkit-scrollbar,
     .terminal-container::-webkit-scrollbar,
-    .partnerships-grid::-webkit-scrollbar,
     .partnership-card::-webkit-scrollbar,
     .ecosystem-card::-webkit-scrollbar,
     .community-content::-webkit-scrollbar,

--- a/css/scroll-fix.css
+++ b/css/scroll-fix.css
@@ -89,7 +89,6 @@
         display: block !important;
     }
     
-    #partnerships .partnerships-grid,
     #partnerships .partnership-card,
     #ecosystem .ecosystem-grid,
     #community .community-content,
@@ -106,6 +105,19 @@
     }
     
     #ecosystem .ecosystem-card {
+        height: auto !important;
+        max-height: none !important;
+        overflow: hidden !important;
+    }
+    
+    /* Allow partnerships cards to extend beyond bounds during hover */
+    #partnerships .partnerships-grid {
+        overflow: visible !important;
+        overflow-x: visible !important;
+        overflow-y: visible !important;
+    }
+    
+    #partnerships .partnership-card {
         height: auto !important;
         max-height: none !important;
         overflow: hidden !important;

--- a/css/scroll-fix.css
+++ b/css/scroll-fix.css
@@ -92,10 +92,20 @@
     #partnerships .partnerships-grid,
     #partnerships .partnership-card,
     #ecosystem .ecosystem-grid,
-    #ecosystem .ecosystem-card,
     #community .community-content,
     #community .twitter-feed,
     #community .telegram-feed {
+        height: auto !important;
+        max-height: none !important;
+        overflow: hidden !important;
+    }
+    
+    /* Allow ecosystem cards to extend beyond bounds during hover */
+    #ecosystem .ecosystem-grid {
+        overflow: visible !important;
+    }
+    
+    #ecosystem .ecosystem-card {
         height: auto !important;
         max-height: none !important;
         overflow: hidden !important;

--- a/css/style.css
+++ b/css/style.css
@@ -2434,6 +2434,7 @@ body {
     grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
     gap: 30px;
     margin-top: 40px;
+    padding-top: 10px; /* Add padding to accommodate hover translateY effect */
 }
 
 .ecosystem-card {

--- a/css/style.css
+++ b/css/style.css
@@ -2574,6 +2574,7 @@ body {
     max-width: 1200px;
     margin-left: auto;
     margin-right: auto;
+    padding-top: 10px; /* Add padding to accommodate hover translateY effect */
 }
 
 .partnership-card {
@@ -4043,6 +4044,17 @@ body {
     .chat-input {
         padding: 10px 15px;
     }
+}
+
+/* Override inline overflow styles for partnerships section */
+#partnerships.section {
+    overflow: visible !important;
+}
+
+#partnerships .partnerships-grid {
+    overflow: visible !important;
+    overflow-x: visible !important;
+    overflow-y: visible !important;
 }
 
 /* Planned/Disabled ecosystem card styles */


### PR DESCRIPTION
Fixes ECOSYSTEM section cards being clipped at the top on hover by adjusting overflow properties and adding top padding.

---
<a href="https://cursor.com/background-agent?bcId=bc-af1d5e18-4c1b-4823-ae17-dc3f56e607d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af1d5e18-4c1b-4823-ae17-dc3f56e607d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

