### PR TITLE
Fix desktop menu and telegram bots icon

### DIFF
--- a/ai-companions.html
+++ b/ai-companions.html
@@ -291,7 +291,7 @@
                 
                 <div class="social-links">
                     <a href="https://x.com/mega_buddies" class="social-link" target="_blank"><i class="fab fa-twitter"></i></a>
-                    <a href="https://t.me/megabuddies" class="social-link" target="_blank"><i class="fab fa-discord"></i></a>
+                    <a href="https://t.me/megabuddies" class="social-link" target="_blank"><i class="fab fa-telegram"></i></a>
                     <a href="https://megaeth.com" class="social-link" target="_blank"><i class="fas fa-globe"></i></a>
                 </div>
             </div>

--- a/css/style.css
+++ b/css/style.css
@@ -703,6 +703,13 @@ body {
   cursor: pointer;
 }
 
+/* Скрываем бургер меню на десктопе */
+@media (min-width: 993px) {
+  .mobile-menu-toggle {
+    display: none !important;
+  }
+}
+
 .mobile-menu-toggle span {
   display: block;
   width: 100%;

--- a/telegram-bots.html
+++ b/telegram-bots.html
@@ -316,7 +316,7 @@
                     <p>Join our community and show your dedication to the "Build Different" philosophy. Active community members receive invitations.</p>
                     <a href="https://t.me/megabuddies" target="_blank" class="access-btn neon-button">
                         JOIN COMMUNITY
-                        <i class="fab fa-discord"></i>
+                        <i class="fab fa-telegram"></i>
                     </a>
                 </div>
                 
@@ -353,7 +353,7 @@
                 
                 <div class="social-links">
                     <a href="https://x.com/mega_buddies" class="social-link" target="_blank"><i class="fab fa-twitter"></i></a>
-                    <a href="https://t.me/megabuddies" class="social-link" target="_blank"><i class="fab fa-discord"></i></a>
+                    <a href="https://t.me/megabuddies" class="social-link" target="_blank"><i class="fab fa-telegram"></i></a>
                     <a href="https://megaeth.com" class="social-link" target="_blank"><i class="fas fa-globe"></i></a>
                 </div>
             </div>


### PR DESCRIPTION
Hide the mobile menu toggle on desktop and replace incorrect Discord icons with Telegram icons for Telegram links.

---
<a href="https://cursor.com/background-agent?bcId=bc-008f6b36-a559-49e4-b39b-deb988fa42b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-008f6b36-a559-49e4-b39b-deb988fa42b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

