### PR TITLE
Embed ambassador bot twitter preview dark theme

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3187,6 +3187,52 @@ body {
     letter-spacing: 1px;
 }
 
+/* Twitter Embed Section */
+.twitter-embed-section {
+    margin-top: 50px;
+}
+
+.twitter-embed-section h3 {
+    font-family: var(--font-display);
+    font-size: 20px;
+    color: var(--accent-color);
+    margin-bottom: 25px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.twitter-embed-container {
+    display: flex;
+    justify-content: center;
+    padding: 20px;
+    background: rgba(18, 18, 24, 0.3);
+    border: 1px solid rgba(112, 135, 227, 0.2);
+    border-radius: 10px;
+    margin: 0 auto;
+    max-width: 600px;
+}
+
+.twitter-embed-container .twitter-tweet {
+    margin: 0 !important;
+}
+
+/* Dark theme for Twitter embed */
+.twitter-embed-container iframe {
+    border-radius: 8px;
+}
+
+/* Mobile responsive for Twitter embed */
+@media (max-width: 768px) {
+    .twitter-embed-section {
+        margin-top: 30px;
+    }
+    
+    .twitter-embed-container {
+        padding: 15px;
+        max-width: 100%;
+    }
+}
+
 .roles-list {
     display: grid;
     gap: 20px;

--- a/telegram-bots.html
+++ b/telegram-bots.html
@@ -237,6 +237,14 @@
                         </div>
                     </div>
                 </div>
+                
+                <!-- Twitter Embed -->
+                <div class="twitter-embed-section">
+                    <h3>Latest Updates</h3>
+                    <div class="twitter-embed-container">
+                        <blockquote class="twitter-tweet"><p lang="en" dir="ltr">Meet the Mega Buddies Ambassador Bot — the most gamified, rewarding, and alive community experience in web3! <br><br>You've never seen anything like this. Every line of code handcrafted by your Buddy.<br><br>Submit <a href="https://twitter.com/megaeth_labs?ref_src=twsrc%5Etfw">@megaeth_labs</a> or <a href="https://twitter.com/mega_buddies?ref_src=twsrc%5Etfw">@mega_buddies</a> content -&gt; get rated -&gt; earn unclaimed stars… <a href="https://t.co/eMMu3mUFnl">pic.twitter.com/eMMu3mUFnl</a></p>&mdash; Mega Buddies 🐰 (@mega_buddies) <a href="https://twitter.com/mega_buddies/status/1953773773494141384?ref_src=twsrc%5Etfw">August 8, 2025</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+                    </div>
+                </div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
Add Twitter embed for the Ambassador Bot to display latest updates, styled for the dark theme.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ded1c3f-40ac-4bb5-bdc1-0580e6f38eec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ded1c3f-40ac-4bb5-bdc1-0580e6f38eec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

