### PR TITLE
Fix desktop top menu highlighting and extra element

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -371,23 +371,32 @@ html, body {
   overflow-x: hidden;
 }
 
-/* Показываем улучшенную бургер-кнопку в мобильной версии */
-.mobile-menu-toggle {
-  display: flex !important;
-  position: fixed;
-  top: 10px;
-  right: 15px;
-  z-index: 1002;
-  width: 44px;
-  height: 44px;
-  background: rgba(18, 18, 24, 0.9);
-  border: 2px solid var(--accent-color);
-  border-radius: 8px;
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  box-shadow: 0 0 15px var(--accent-glow-color);
-  cursor: pointer;
-  transition: all 0.3s ease;
+/* Показываем улучшенную бургер-кнопку только в мобильной версии */
+@media (max-width: 992px) {
+  .mobile-menu-toggle {
+    display: flex !important;
+    position: fixed;
+    top: 10px;
+    right: 15px;
+    z-index: 1002;
+    width: 44px;
+    height: 44px;
+    background: rgba(18, 18, 24, 0.9);
+    border: 2px solid var(--accent-color);
+    border-radius: 8px;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow: 0 0 15px var(--accent-glow-color);
+    cursor: pointer;
+    transition: all 0.3s ease;
+  }
+}
+
+/* Принудительно скрываем на десктопе */
+@media (min-width: 993px) {
+  .mobile-menu-toggle {
+    display: none !important;
+  }
 }
 
 /* Базовые мобильные настройки для всех экранов меньше 992px */

--- a/css/style.css
+++ b/css/style.css
@@ -2778,6 +2778,21 @@ body {
 /* Ensure dropdown-toggle inherits nav-link hover effects */
 .dropdown-toggle {
     position: relative;
+    /* Наследуем все базовые стили от nav-link */
+    font-family: var(--font-mono);
+    color: var(--text-color);
+    text-decoration: none;
+    font-size: 0.9rem;
+    padding: 5px 8px;
+    transition: all 0.3s cubic-bezier(0.22, 0.61, 0.36, 1);
+    letter-spacing: 1px;
+    display: inline-block;
+    text-shadow: 0 0 5px rgba(146, 147, 151, 0.5);
+    border: 1px solid var(--accent-color);
+    border-radius: 2px;
+    background: rgba(146, 147, 151, 0.05);
+    overflow: hidden;
+    box-shadow: 0 0 3px rgba(146, 147, 151, 0.2);
 }
 
 .dropdown-toggle::before {
@@ -2791,6 +2806,23 @@ body {
     transform: scaleX(0);
     transform-origin: left;
     transition: transform 0.4s cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+.dropdown-toggle::after {
+    content: '';
+    position: absolute;
+    top: -2px;
+    left: -2px;
+    right: -2px;
+    bottom: -2px;
+    border-radius: 4px;
+    background: linear-gradient(45deg, 
+                               var(--accent-color), 
+                               transparent, 
+                               var(--accent-color));
+    opacity: 0;
+    transition: opacity 0.4s ease;
+    z-index: -1;
 }
 
 .dropdown:hover .dropdown-toggle,
@@ -2807,6 +2839,11 @@ body {
 .dropdown:hover .dropdown-toggle::before,
 .dropdown-toggle:hover::before {
     transform: scaleX(1);
+}
+
+.dropdown:hover .dropdown-toggle::after,
+.dropdown-toggle:hover::after {
+    opacity: 0.3;
 }
 
 .dropdown-menu {


### PR DESCRIPTION
Improve UI consistency by fixing the ECOSYSTEM button's hover highlighting and hiding the mobile menu toggle on desktop.

---
<a href="https://cursor.com/background-agent?bcId=bc-5648f0ca-a056-4acc-8c1d-ff171b3e3920">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5648f0ca-a056-4acc-8c1d-ff171b3e3920">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

