### PR TITLE
Fix incomplete ecosystem button highlight

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -53,7 +53,7 @@
   text-transform: uppercase;
   letter-spacing: 0.3px;
   text-align: center;
-  max-width: 60px;
+  max-width: 70px;
 }
 
 .mobile-nav-item:hover,
@@ -72,8 +72,6 @@
   font-size: 8px;
   line-height: 1;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   max-width: 100%;
 }
 
@@ -1340,7 +1338,7 @@ html, body {
   /* Еще более компактное нижнее меню для маленьких экранов */
   .mobile-nav-item {
     min-width: 40px;
-    max-width: 50px;
+    max-width: 65px;
     padding: 4px 2px;
   }
   
@@ -1352,6 +1350,7 @@ html, body {
   .mobile-nav-item span {
     font-size: 7px;
     letter-spacing: 0.2px;
+    white-space: nowrap;
   }
   
   .mobile-bottom-nav {


### PR DESCRIPTION
Fix incomplete highlighting of the Ecosystem button in mobile navigation.

The button's `max-width` was too restrictive, causing the "Ecosystem" text to be cut off and the active state highlight to appear incomplete. This PR increases the button's width and removes text truncation styles to ensure full visibility and proper highlighting across different mobile screen sizes.

---
<a href="https://cursor.com/background-agent?bcId=bc-f8893de5-6db1-4fd2-bfe2-3515a662c41c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f8893de5-6db1-4fd2-bfe2-3515a662c41c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

