### PR TITLE
Fix ecosystem button highlighting in desktop navigation

### DIFF
--- a/ai-companions.html
+++ b/ai-companions.html
@@ -33,7 +33,7 @@
                     <li class="nav-item"><a href="index.html#about" class="nav-link">ABOUT</a></li>
                     <li class="nav-item"><a href="index.html#manifesto" class="nav-link">MANIFESTO</a></li>
                     <li class="nav-item dropdown active">
-                        <a href="index.html#ecosystem" class="nav-link dropdown-toggle">ECOSYSTEM</a>
+                        <a href="index.html#ecosystem" class="nav-link dropdown-toggle">ECOSYSTEM<span class="dropdown-arrow">▼</span></a>
                         <ul class="dropdown-menu">
                             <li><a href="telegram-bots.html" class="dropdown-link">
                                 <i class="fab fa-telegram"></i>

--- a/css/style.css
+++ b/css/style.css
@@ -2764,14 +2764,15 @@ body {
     position: relative;
 }
 
-.dropdown-toggle::after {
-    content: '▼';
+/* Dropdown arrow using a span element instead of ::after */
+.dropdown-toggle .dropdown-arrow {
     font-size: 10px;
     margin-left: 8px;
     transition: transform 0.3s ease;
+    display: inline-block;
 }
 
-.dropdown:hover .dropdown-toggle::after {
+.dropdown:hover .dropdown-toggle .dropdown-arrow {
     transform: rotate(180deg);
 }
 
@@ -2929,7 +2930,7 @@ body {
         backdrop-filter: none;
     }
     
-    .dropdown-toggle::after {
+    .dropdown-toggle .dropdown-arrow {
         display: none;
     }
     

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
                     <li class="nav-item"><a href="#manifesto" class="nav-link">MANIFESTO</a></li>
                     <li class="nav-item"><a href="#collection" class="nav-link">COLLECTION</a></li>
                     <li class="nav-item dropdown">
-                        <a href="#ecosystem" class="nav-link dropdown-toggle">ECOSYSTEM</a>
+                        <a href="#ecosystem" class="nav-link dropdown-toggle">ECOSYSTEM<span class="dropdown-arrow">▼</span></a>
                         <ul class="dropdown-menu">
                             <li><a href="telegram-bots.html" class="dropdown-link">
                                 <i class="fab fa-telegram"></i>

--- a/mobile.html
+++ b/mobile.html
@@ -55,7 +55,7 @@
                     <li class="nav-item"><a href="#collection" class="nav-link">COLLECTION</a></li>
                     <li class="nav-item"><a href="#partnerships" class="nav-link">PARTNERSHIPS</a></li>
                     <li class="nav-item dropdown">
-                        <a href="#ecosystem" class="nav-link dropdown-toggle">ECOSYSTEM</a>
+                        <a href="#ecosystem" class="nav-link dropdown-toggle">ECOSYSTEM<span class="dropdown-arrow">▼</span></a>
                         <ul class="dropdown-menu">
                             <li><a href="telegram-bots.html" class="dropdown-link">
                                 <i class="fab fa-telegram"></i>

--- a/telegram-bots.html
+++ b/telegram-bots.html
@@ -33,7 +33,7 @@
                     <li class="nav-item"><a href="index.html#about" class="nav-link">ABOUT</a></li>
                     <li class="nav-item"><a href="index.html#manifesto" class="nav-link">MANIFESTO</a></li>
                     <li class="nav-item dropdown active">
-                        <a href="index.html#ecosystem" class="nav-link dropdown-toggle">ECOSYSTEM</a>
+                        <a href="index.html#ecosystem" class="nav-link dropdown-toggle">ECOSYSTEM<span class="dropdown-arrow">▼</span></a>
                         <ul class="dropdown-menu">
                             <li><a href="telegram-bots.html" class="dropdown-link active">
                                 <i class="fab fa-telegram"></i>


### PR DESCRIPTION
Fix incomplete highlighting of the Ecosystem button by resolving conflicting `::after` pseudo-elements.

The original CSS used two `::after` pseudo-elements on `.dropdown-toggle`: one for the dropdown arrow and another for the background highlighting. The highlighting `::after` (with `content: ''`) was overriding the arrow `::after` (with `content: '▼'`), causing the arrow to disappear and the highlighting to not render correctly. This PR moves the dropdown arrow to a dedicated `<span>` element to prevent this conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4954bbc-9e7e-4dec-ad5a-e1354f37a270">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d4954bbc-9e7e-4dec-ad5a-e1354f37a270">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

