### PR TITLE
Fix blue highlight on documentation card

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,7 +337,7 @@
                     </a>
                 </div>
 
-                <div class="ecosystem-card neon-glow highlight" data-feature="docs">
+                <div class="ecosystem-card neon-glow" data-feature="docs">
                     <div class="ecosystem-icon">
                         <i class="fas fa-book"></i>
                     </div>

--- a/mobile.html
+++ b/mobile.html
@@ -243,7 +243,7 @@
                     </a>
                 </div>
 
-                <div class="ecosystem-card neon-glow highlight" data-feature="docs">
+                <div class="ecosystem-card neon-glow" data-feature="docs">
                     <div class="ecosystem-icon">
                         <i class="fas fa-book"></i>
                     </div>


### PR DESCRIPTION
Remove `highlight` class from the Documentation card to fix its permanent blue highlight.

The `highlight` class was inadvertently applied to the Documentation card in both desktop and mobile versions, causing it to always display with a blue border and shadow, rather than only on hover or interaction.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc45810f-c0f0-4c46-8544-34237842f028">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc45810f-c0f0-4c46-8544-34237842f028">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

