### PR TITLE
Fix scroll down button to bottom

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -679,6 +679,7 @@ html, body {
     overflow: hidden;
     position: relative;
     padding-top: 0;
+    padding-bottom: 5rem;
     min-height: auto;
     display: flex;
     flex-direction: column;

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -808,8 +808,8 @@ html, body {
   
   /* Исправление для скролл-индикатора (прокрутите вниз) */
   .scroll-indicator {
-    position: absolute;
-    bottom: 10px;
+    position: fixed;
+    bottom: 1rem;
     left: 50%;
     transform: translateX(-50%);
     text-align: center;
@@ -818,6 +818,7 @@ html, body {
     align-items: center;
     justify-content: center;
     width: auto;
+    z-index: 1000;
     margin: 0 auto;
   }
   
@@ -1452,7 +1453,7 @@ html, body {
   
   /* Размещение скролл-индикатора */
   .scroll-indicator {
-    bottom: 10px;
+    bottom: 1rem;
   }
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -895,15 +895,15 @@ body {
 }
 
 .scroll-indicator {
-  position: absolute;
-  bottom: 7rem;
+  position: fixed;
+  bottom: 2rem;
   left: 50%;
   transform: translateX(-50%);
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: clamp(0.5rem, 1vh, 1rem);
-  z-index: 3;
+  z-index: 1000;
   opacity: 0.9;
   transition: all 0.3s ease;
   cursor: pointer;
@@ -992,15 +992,16 @@ body {
   }
   
   .scroll-indicator {
-    position: relative;
-    bottom: auto;
-    left: auto;
-    transform: none;
-    margin: 4vh auto 0;
+    position: fixed;
+    bottom: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    margin: 0;
+    z-index: 1000;
   }
   
   .scroll-indicator:hover {
-    transform: translateY(-5px);
+    transform: translateX(-50%) translateY(-5px);
   }
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -727,6 +727,7 @@ body {
   justify-content: center;
   overflow: hidden;
   padding-top: 60px;
+  padding-bottom: 8rem;
   max-height: 100vh;
 }
 
@@ -966,6 +967,10 @@ body {
 }
 
 @media (max-width: 768px) {
+  .hero {
+    padding-bottom: 6rem;
+  }
+  
   .hero-title-container {
     flex-direction: column;
     gap: 1rem;


### PR DESCRIPTION
Set the SCROLL DOWN button to `position: fixed` to ensure it always remains visible at the bottom of the viewport on all devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac2d0b91-6170-4b3a-a099-3953d3155ac9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac2d0b91-6170-4b3a-a099-3953d3155ac9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

