### PR TITLE
Adjust desktop twitter preview to match card

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2587,7 +2587,7 @@ body {
     max-width: 1200px;
     margin-left: auto;
     margin-right: auto;
-    padding-top: 10px; /* Add padding to accommodate hover translateY effect */
+    /* Убираем padding-top чтобы карточки начинались от верха */
 }
 
 .partnership-card {
@@ -2720,12 +2720,16 @@ body {
     display: flex;
     justify-content: center;
     align-items: center;
+    /* Увеличиваем ширину для desktop */
+    width: 100%;
 }
 
 .twitter-embed-container .twitter-tweet {
     margin: 0 auto !important;
     max-width: 100% !important;
     min-height: 200px;
+    /* Принудительно устанавливаем ширину для desktop */
+    width: 100% !important;
 }
 
 /* Responsive design for partnerships */
@@ -2762,6 +2766,29 @@ body {
     .partnership-card {
         padding: 20px;
         min-height: 450px;
+    }
+}
+
+/* Стили для desktop версии - делаем Twitter встраивания шире */
+@media (min-width: 992px) {
+    .twitter-embed-container {
+        width: 100%;
+        max-width: none;
+        padding: 0;
+    }
+    
+    .twitter-embed-container .twitter-tweet {
+        width: 100% !important;
+        max-width: none !important;
+        /* Увеличиваем минимальную ширину для desktop */
+        min-width: 400px !important;
+    }
+    
+    /* Убеждаемся что iframe внутри Twitter встраивания тоже широкий */
+    .twitter-embed-container .twitter-tweet iframe {
+        width: 100% !important;
+        max-width: none !important;
+        min-width: 400px !important;
     }
 }
 

--- a/js/scroll-animations.js
+++ b/js/scroll-animations.js
@@ -181,7 +181,7 @@ document.addEventListener('DOMContentLoaded', function() {
         ease: 'back.out(1.7)',
         clearProps: 'all'
     }, '-=0.3')
-    .from('.twitter-preview', {
+    .from('.twitter-embed-container', {
         opacity: 0,
         y: 15,
         duration: 0.4,


### PR DESCRIPTION
Improve Twitter preview display in desktop by making them full width, removing top padding, and correcting the animation selector.

---
<a href="https://cursor.com/background-agent?bcId=bc-24ce46d2-fb28-4f38-839d-7a0b18aefd4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24ce46d2-fb28-4f38-839d-7a0b18aefd4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

