### PR TITLE
Fix sticky scroll down button position

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -769,11 +769,14 @@ html, body {
   }
   
   .mobile-scroll-indicator {
-    position: relative;
-    bottom: 0;
-    margin-top: 10px;
+    position: absolute;
+    bottom: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    margin-top: 0;
     pointer-events: none;
     cursor: default;
+    transition: opacity 0.5s ease;
   }
   
   /* Компактный вид подзаголовка и текста */
@@ -809,7 +812,7 @@ html, body {
   
   /* Исправление для скролл-индикатора (прокрутите вниз) */
   .scroll-indicator {
-    position: fixed;
+    position: absolute;
     bottom: 1rem;
     left: 50%;
     transform: translateX(-50%);

--- a/css/style.css
+++ b/css/style.css
@@ -896,7 +896,7 @@ body {
 }
 
 .scroll-indicator {
-  position: fixed;
+  position: absolute;
   bottom: 2rem;
   left: 50%;
   transform: translateX(-50%);
@@ -906,7 +906,7 @@ body {
   gap: clamp(0.5rem, 1vh, 1rem);
   z-index: 1000;
   opacity: 0.9;
-  transition: all 0.3s ease;
+  transition: all 0.3s ease, opacity 0.5s ease;
   cursor: pointer;
 }
 
@@ -997,7 +997,7 @@ body {
   }
   
   .scroll-indicator {
-    position: fixed;
+    position: absolute;
     bottom: 1rem;
     left: 50%;
     transform: translateX(-50%);

--- a/js/main.js
+++ b/js/main.js
@@ -345,6 +345,32 @@ document.addEventListener('DOMContentLoaded', function() {
                 });
             }
         });
+
+        // Обработчик скролла для скрытия кнопки scroll-down
+        function handleScrollIndicatorVisibility() {
+            const heroSection = document.getElementById('home');
+            if (heroSection && scrollIndicator) {
+                const heroHeight = heroSection.offsetHeight;
+                const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+                
+                // Скрываем кнопку, если прокрутили больше чем на 80% от высоты героической секции
+                const hideThreshold = heroHeight * 0.8;
+                
+                if (scrollTop > hideThreshold) {
+                    scrollIndicator.style.opacity = '0';
+                    scrollIndicator.style.pointerEvents = 'none';
+                } else {
+                    scrollIndicator.style.opacity = '0.9';
+                    scrollIndicator.style.pointerEvents = 'auto';
+                }
+            }
+        }
+
+        // Добавляем обработчик скролла
+        window.addEventListener('scroll', handleScrollIndicatorVisibility);
+        
+        // Вызываем функцию при загрузке для корректной инициализации
+        handleScrollIndicatorVisibility();
     }
     
     // Эффект печатающегося текста для терминала

--- a/js/mobile-optimize.js
+++ b/js/mobile-optimize.js
@@ -129,6 +129,30 @@ document.addEventListener('DOMContentLoaded', function() {
         if (scrollIndicator) {
             scrollIndicator.style.pointerEvents = 'none';
             scrollIndicator.style.cursor = 'default';
+            
+            // Обработчик скролла для скрытия кнопки scroll-down на мобильных
+            function handleMobileScrollIndicatorVisibility() {
+                const heroSection = document.getElementById('home');
+                if (heroSection && scrollIndicator) {
+                    const heroHeight = heroSection.offsetHeight;
+                    const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+                    
+                    // Скрываем кнопку, если прокрутили больше чем на 70% от высоты героической секции
+                    const hideThreshold = heroHeight * 0.7;
+                    
+                    if (scrollTop > hideThreshold) {
+                        scrollIndicator.style.opacity = '0';
+                    } else {
+                        scrollIndicator.style.opacity = '0.9';
+                    }
+                }
+            }
+
+            // Добавляем обработчик скролла для мобильных
+            window.addEventListener('scroll', handleMobileScrollIndicatorVisibility, { passive: true });
+            
+            // Вызываем функцию при загрузке для корректной инициализации
+            handleMobileScrollIndicatorVisibility();
         }
         
         if (isMobile()) {


### PR DESCRIPTION
Hide the "scroll down" button when scrolling past the initial hero section to prevent it from overlaying other content.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5a575ed-dd39-4e4b-9b81-d7959005233d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d5a575ed-dd39-4e4b-9b81-d7959005233d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

