### PR TITLE
Make mega buddies text responsive

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -453,13 +453,18 @@ html, body {
   }
   
   .logo {
-    font-size: 16px;
+    font-size: clamp(14px, 4vw, 18px);
     padding: 8px 0;
+    max-width: calc(100vw - 100px);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   
   .logo img {
     max-height: 30px;
     margin-right: 5px;
+    flex-shrink: 0;
   }
   
   /* Манифест */
@@ -752,9 +757,10 @@ html, body {
   }
   
   .mobile-hero .hero-title {
-    font-size: 38px;
+    font-size: clamp(28px, 8vw, 38px);
     margin: 0;
     line-height: 1;
+    text-align: center;
   }
   
   .mobile-hero .hero-subtitle {
@@ -1433,7 +1439,8 @@ html, body {
   }
   
   .hero-title {
-    font-size: 40px;
+    font-size: clamp(30px, 7vw, 40px);
+    text-align: center;
   }
   
   /* Корректировка кнопок в ландшафтном режиме */
@@ -1664,9 +1671,10 @@ html.slow-connection img {
   }
 
   .hero-title {
-    font-size: 36px;
+    font-size: clamp(26px, 6vw, 36px);
     margin-bottom: 0;
     line-height: 0.9;
+    text-align: center;
   }
 
   .hero-subtitle {

--- a/css/style.css
+++ b/css/style.css
@@ -62,25 +62,31 @@
     flex-direction: column;
     align-items: center;
     gap: 15px;
+    max-width: 95vw;
+    padding: 0 10px;
 }
 
 /* Обновляем стили для заголовка прелоадера */
 .preloader-title {
     font-family: var(--font-display);
-    font-size: 24px;
+    font-size: clamp(18px, 5vw, 24px);
     color: var(--accent-color);
-    letter-spacing: 2px;
+    letter-spacing: clamp(1px, 0.5vw, 2px);
     text-align: center;
     margin: 0;
+    max-width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 /* Основной контейнер прелоадера с CRT эффектом */
 .preloader-content {
     text-align: center;
-    width: 320px;
+    width: clamp(280px, 90vw, 320px);
     border: 2px solid var(--accent-color);
     border-radius: 5px;
-    padding: 30px;
+    padding: clamp(20px, 5vw, 30px);
     background-color: rgba(18, 18, 24, 0.8);
     box-shadow: 0 0 20px var(--accent-glow-color),
                 0 0 40px rgba(146, 147, 151, calc(var(--glow-intensity) * 0.3));
@@ -90,6 +96,7 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    max-width: calc(100vw - 40px);
 }
 
 /* Добавляем рамку с градиентом */
@@ -748,9 +755,11 @@ body {
   gap: 0;
   margin-bottom: 2rem;
   white-space: nowrap;
-  padding: 0 2rem;
+  padding: 0 1rem;
   position: relative;
   z-index: 2;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 #hero-animation {
@@ -1068,6 +1077,7 @@ body {
   .hero-title-container {
     flex-direction: column;
     gap: 1rem;
+    padding: 0 0.5rem;
   }
   
   #hero-animation {
@@ -1081,8 +1091,9 @@ body {
   }
   
   .hero-title {
-    font-size: clamp(1.8rem, 5vw, 2.5rem);
+    font-size: clamp(1.8rem, 8vw, 2.5rem);
     padding: 0;
+    text-align: center;
   }
   
   .hero-title.mega,
@@ -1106,7 +1117,12 @@ body {
 
 @media (max-width: 576px) {
   .hero-title {
-    font-size: 2rem;
+    font-size: clamp(1.5rem, 7vw, 2rem);
+    text-align: center;
+  }
+  
+  .hero-title-container {
+    padding: 0 0.25rem;
   }
   
   .hero-description {
@@ -2080,12 +2096,12 @@ body {
 
 /* Увеличиваем отступы для текста, чтобы дать больше места модели */
 .hero-title.mega {
-  margin-right: 300px; /* Базовый отступ, который JavaScript может уточнить */
+  margin-right: clamp(50px, 15vw, 300px); /* Адаптивный отступ */
   transition: margin 0.3s ease;
 }
 
 .hero-title.buddies {
-  margin-left: 300px; /* Базовый отступ, который JavaScript может уточнить */
+  margin-left: clamp(50px, 15vw, 300px); /* Адаптивный отступ */
   transition: margin 0.3s ease;
 }
 
@@ -2150,12 +2166,17 @@ body {
   }
   
   .logo {
-    font-size: 20px;
+    font-size: clamp(16px, 4vw, 20px);
     z-index: 1001;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: calc(100vw - 100px); /* Оставляем место для гамбургер-меню */
   }
   
   .logo img {
     max-width: 40px;
+    flex-shrink: 0;
   }
   
   .nav-list {
@@ -2328,8 +2349,8 @@ body {
   }
   
   .preloader-content {
-    width: 290px;
-    padding: 20px;
+    width: clamp(250px, 85vw, 290px);
+    padding: clamp(15px, 4vw, 20px);
   }
   
   .hero-title {
@@ -2372,12 +2393,26 @@ body {
 /* Small mobile devices (iPhone SE, etc) */
 @media (max-width: 375px) {
   .preloader-content {
-    width: 250px;
-    padding: 15px;
+    width: clamp(220px, 80vw, 250px);
+    padding: clamp(10px, 3vw, 15px);
+  }
+  
+  .logo {
+    font-size: clamp(14px, 5vw, 18px);
+    max-width: calc(100vw - 80px);
+  }
+  
+  .logo img {
+    max-width: 35px;
   }
   
   .hero-title {
-    font-size: 32px;
+    font-size: clamp(24px, 6vw, 32px);
+    text-align: center;
+  }
+  
+  .hero-title-container {
+    padding: 0 0.125rem;
   }
   
   .hero-subtitle {


### PR DESCRIPTION
Make "MEGA BUDDIES" text responsive across all sections (header, hero, preloader) to prevent truncation on various screen sizes.

The text was previously using fixed font sizes and margins, causing it to overflow and be cut off on smaller screens. This PR introduces adaptive CSS properties like `clamp()`, `max-width`, `overflow: hidden`, and updated media queries to ensure the text scales correctly and remains visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d24ee32-02ae-40f1-9c2d-fb6b14f3f9d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3d24ee32-02ae-40f1-9c2d-fb6b14f3f9d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

