### PR TITLE
Link zealy quests button to questboard

### DIFF
--- a/ai-companions.html
+++ b/ai-companions.html
@@ -39,7 +39,7 @@
                                 <i class="fab fa-telegram"></i>
                                 <span>Telegram Bots</span>
                             </a></li>
-                            <li><a href="zealy-quests.html" class="dropdown-link">
+                            <li><a href="https://zealy.io/cw/megabuddies/questboard/" target="_blank" class="dropdown-link">
                                 <i class="fas fa-trophy"></i>
                                 <span>Zealy Quests</span>
                             </a></li>
@@ -301,7 +301,7 @@
                     <h3 class="footer-nav-title">Ecosystem</h3>
                     <ul class="footer-nav-links">
                         <li class="footer-nav-link"><a href="telegram-bots.html">Telegram Bots</a></li>
-                        <li class="footer-nav-link"><a href="zealy-quests.html">Zealy Quests</a></li>
+                        <li class="footer-nav-link"><a href="https://zealy.io/cw/megabuddies/questboard/" target="_blank">Zealy Quests</a></li>
                         <li class="footer-nav-link"><a href="ai-companions.html">AI Companions</a></li>
                         <li class="footer-nav-link"><a href="https://buddyrunner.fun" target="_blank">Buddy Runner</a></li>
                         <li class="footer-nav-link"><span class="planned">Leaderboard (Planned)</span></li>

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
                                 <i class="fab fa-telegram"></i>
                                 <span>Telegram Bots</span>
                             </a></li>
-                            <li><a href="zealy-quests.html" class="dropdown-link">
+                            <li><a href="https://zealy.io/cw/megabuddies/questboard/" target="_blank" class="dropdown-link">
                                 <i class="fas fa-trophy"></i>
                                 <span>Zealy Quests</span>
                             </a></li>

--- a/js/device-detector.js
+++ b/js/device-detector.js
@@ -28,7 +28,6 @@
     function isOnEcosystemPage() {
         return window.location.pathname.indexOf('telegram-bots.html') !== -1 ||
                window.location.pathname.indexOf('ai-companions.html') !== -1 ||
-               window.location.pathname.indexOf('zealy-quests.html') !== -1 ||
                window.location.pathname.indexOf('leaderboard.html') !== -1;
     }
 

--- a/mobile.html
+++ b/mobile.html
@@ -47,7 +47,7 @@
                                 <i class="fab fa-telegram"></i>
                                 <span>Telegram Bots</span>
                             </a></li>
-                            <li><a href="zealy-quests.html" class="dropdown-link">
+                            <li><a href="https://zealy.io/cw/megabuddies/questboard/" target="_blank" class="dropdown-link">
                                 <i class="fas fa-trophy"></i>
                                 <span>Zealy Quests</span>
                             </a></li>

--- a/telegram-bots.html
+++ b/telegram-bots.html
@@ -39,7 +39,7 @@
                                 <i class="fab fa-telegram"></i>
                                 <span>Telegram Bots</span>
                             </a></li>
-                            <li><a href="zealy-quests.html" class="dropdown-link">
+                            <li><a href="https://zealy.io/cw/megabuddies/questboard/" target="_blank" class="dropdown-link">
                                 <i class="fas fa-trophy"></i>
                                 <span>Zealy Quests</span>
                             </a></li>
@@ -371,7 +371,7 @@
                     <h3 class="footer-nav-title">Ecosystem</h3>
                     <ul class="footer-nav-links">
                         <li class="footer-nav-link"><a href="telegram-bots.html">Telegram Bots</a></li>
-                        <li class="footer-nav-link"><a href="zealy-quests.html">Zealy Quests</a></li>
+                        <li class="footer-nav-link"><a href="https://zealy.io/cw/megabuddies/questboard/" target="_blank">Zealy Quests</a></li>
                         <li class="footer-nav-link"><a href="ai-companions.html">AI Companions</a></li>
                         <li class="footer-nav-link"><a href="https://buddyrunner.fun" target="_blank">Buddy Runner</a></li>
                         <li class="footer-nav-link"><span class="planned">Leaderboard (Planned)</span></li>


### PR DESCRIPTION
Update all 'ZEALY QUESTS' links to point to the external Zealy questboard URL.

Previously, these links pointed to a non-existent `zealy-quests.html` file. This PR corrects the links to the specified external URL and removes the outdated internal file reference from the device detector script.

---
<a href="https://cursor.com/background-agent?bcId=bc-33464dae-5c37-47f7-b0ee-0cd3c4fb6671">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-33464dae-5c37-47f7-b0ee-0cd3c4fb6671">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

