### PR TITLE
Remove html extension from urls

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -10,6 +10,19 @@ ErrorDocument 404 /404.html
 
 <IfModule mod_rewrite.c>
     RewriteEngine On
+    
+    # Убираем расширение .html из URL
+    # Перенаправляем с .html на чистый URL
+    RewriteCond %{THE_REQUEST} /([^.]+)\.html [NC]
+    RewriteRule ^ /%1? [NC,L,R=301]
+    
+    # Позволяем доступ к файлам без расширения
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_FILENAME}.html -f
+    RewriteRule ^([^.]+)$ $1.html [L]
+    
+    # Существующее правило для изображений
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^images/(.*)$ /images/placeholder.php?name=$1 [L]


### PR DESCRIPTION
Remove `.html` extensions from URLs to make them cleaner and improve SEO.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fb11c3a-df83-43a0-a2a6-3db07c32e639">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fb11c3a-df83-43a0-a2a6-3db07c32e639">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

