### PR TITLE
Удалить расширение .html из имен файлов

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -10,6 +10,18 @@ ErrorDocument 404 /404.html
 
 <IfModule mod_rewrite.c>
     RewriteEngine On
+    
+    # Удаление .html из URL (перенаправление)
+    RewriteCond %{THE_REQUEST} /([^.]+)\.html [NC]
+    RewriteRule ^ /%1? [NC,L,R=301]
+    
+    # Внутреннее перенаправление для URL без расширения на .html файлы
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_FILENAME}.html -f
+    RewriteRule ^([^.]+)$ $1.html [L]
+    
+    # Правило для изображений (существующее)
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^images/(.*)$ /images/placeholder.php?name=$1 [L]

--- a/ai-companions.html
+++ b/ai-companions.html
@@ -24,19 +24,19 @@
     <!-- Header -->
     <header class="main-header">
         <div class="header-container">
-            <a href="index.html" class="logo neon-text">
+            <a href="/" class="logo neon-text">
                 <img src="images/mega-buddies-logo.png" alt="Mega Buddies">
                 MEGA BUDDIES
             </a>
             
             <nav class="main-nav">
                 <ul class="nav-list">
-                    <li class="nav-item"><a href="index.html#about" class="nav-link">ABOUT</a></li>
-                    <li class="nav-item"><a href="index.html#manifesto" class="nav-link">MANIFESTO</a></li>
+                    <li class="nav-item"><a href="/#about" class="nav-link">ABOUT</a></li>
+                    <li class="nav-item"><a href="/#manifesto" class="nav-link">MANIFESTO</a></li>
                     <li class="nav-item dropdown active">
-                        <a href="index.html#ecosystem" class="nav-link dropdown-toggle"><span>ECOSYSTEM</span><span class="dropdown-arrow">▼</span></a>
+                        <a href="/#ecosystem" class="nav-link dropdown-toggle"><span>ECOSYSTEM</span><span class="dropdown-arrow">▼</span></a>
                         <ul class="dropdown-menu">
-                            <li><a href="telegram-bots.html" class="dropdown-link">
+                            <li><a href="telegram-bots" class="dropdown-link">
                                 <i class="fab fa-telegram"></i>
                                 <span>Telegram Bots</span>
                             </a></li>
@@ -44,7 +44,7 @@
                                 <i class="fas fa-trophy"></i>
                                 <span>Zealy Quests</span>
                             </a></li>
-                            <li><a href="ai-companions.html" class="dropdown-link active">
+                            <li><a href="ai-companions" class="dropdown-link active">
                                 <i class="fas fa-robot"></i>
                                 <span>AI Companions</span>
                             </a></li>
@@ -55,9 +55,9 @@
                             </span></li>
                         </ul>
                     </li>
-                    <li class="nav-item"><a href="index.html#collection" class="nav-link">COLLECTION</a></li>
-                    <li class="nav-item"><a href="index.html#roadmap" class="nav-link">ROADMAP</a></li>
-                    <li class="nav-item"><a href="index.html#community" class="nav-link">COMMUNITY</a></li>
+                    <li class="nav-item"><a href="/#collection" class="nav-link">COLLECTION</a></li>
+                    <li class="nav-item"><a href="/#roadmap" class="nav-link">ROADMAP</a></li>
+                    <li class="nav-item"><a href="/#community" class="nav-link">COMMUNITY</a></li>
                     <li class="nav-item"><a href="https://buddyrunner.fun" target="_blank" class="nav-link external-link">
                         BUDDY RUNNER
                         <i class="fas fa-external-link-alt"></i>
@@ -86,9 +86,9 @@
         <div class="container">
             <div class="page-hero-content">
                 <div class="breadcrumbs">
-                    <a href="index.html">HOME</a>
+                    <a href="/">HOME</a>
                     <span>/</span>
-                    <a href="index.html#ecosystem">ECOSYSTEM</a>
+                    <a href="/#ecosystem">ECOSYSTEM</a>
                     <span>/</span>
                     <span class="current">AI COMPANIONS</span>
                 </div>
@@ -276,7 +276,7 @@
     <!-- Back to Ecosystem -->
     <section class="back-section">
         <div class="container">
-            <a href="index.html#ecosystem" class="back-btn neon-button">
+            <a href="/#ecosystem" class="back-btn neon-button">
                 <i class="fas fa-arrow-left"></i>
                 BACK TO ECOSYSTEM
             </a>
@@ -301,9 +301,9 @@
                 <div class="footer-nav-section">
                     <h3 class="footer-nav-title">Ecosystem</h3>
                     <ul class="footer-nav-links">
-                        <li class="footer-nav-link"><a href="telegram-bots.html">Telegram Bots</a></li>
+                        <li class="footer-nav-link"><a href="telegram-bots">Telegram Bots</a></li>
                         <li class="footer-nav-link"><a href="https://zealy.io/cw/megabuddies/questboard/" target="_blank">Zealy Quests</a></li>
-                        <li class="footer-nav-link"><a href="ai-companions.html">AI Companions</a></li>
+                        <li class="footer-nav-link"><a href="ai-companions">AI Companions</a></li>
                         <li class="footer-nav-link"><a href="https://buddyrunner.fun" target="_blank">Buddy Runner</a></li>
                         <li class="footer-nav-link"><span class="planned">Leaderboard (Planned)</span></li>
                     </ul>

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                     <li class="nav-item dropdown">
                         <a href="#ecosystem" class="nav-link dropdown-toggle"><span>ECOSYSTEM</span><span class="dropdown-arrow">▼</span></a>
                         <ul class="dropdown-menu">
-                            <li><a href="telegram-bots.html" class="dropdown-link">
+                            <li><a href="telegram-bots" class="dropdown-link">
                                 <i class="fab fa-telegram"></i>
                                 <span>Telegram Bots</span>
                             </a></li>
@@ -81,7 +81,7 @@
                                 <i class="fas fa-trophy"></i>
                                 <span>Zealy Quests</span>
                             </a></li>
-                            <li><a href="ai-companions.html" class="dropdown-link">
+                            <li><a href="ai-companions" class="dropdown-link">
                                 <i class="fas fa-robot"></i>
                                 <span>AI Companions</span>
                             </a></li>
@@ -249,7 +249,7 @@
                         <span class="feature-tag">Content Rating</span>
                         <span class="feature-tag">WL Rewards</span>
                     </div>
-                    <a href="telegram-bots.html" class="ecosystem-btn neon-button">
+                    <a href="telegram-bots" class="ecosystem-btn neon-button">
                         EXPLORE BOTS
                         <i class="fas fa-arrow-right"></i>
                     </a>
@@ -283,7 +283,7 @@
                         <span class="feature-tag">Character Lore</span>
                         <span class="feature-tag">Nectar AI Powered</span>
                     </div>
-                    <a href="ai-companions.html" class="ecosystem-btn neon-button">
+                    <a href="ai-companions" class="ecosystem-btn neon-button">
                         MEET YOUR BUDDY
                         <i class="fas fa-arrow-right"></i>
                     </a>

--- a/mobile.html
+++ b/mobile.html
@@ -44,7 +44,7 @@
                     <li class="nav-item dropdown">
                         <a href="#ecosystem" class="nav-link dropdown-toggle"><span>ECOSYSTEM</span><span class="dropdown-arrow">▼</span></a>
                         <ul class="dropdown-menu">
-                            <li><a href="telegram-bots.html" class="dropdown-link">
+                            <li><a href="telegram-bots" class="dropdown-link">
                                 <i class="fab fa-telegram"></i>
                                 <span>Telegram Bots</span>
                             </a></li>
@@ -52,7 +52,7 @@
                                 <i class="fas fa-trophy"></i>
                                 <span>Zealy Quests</span>
                             </a></li>
-                            <li><a href="ai-companions.html" class="dropdown-link">
+                            <li><a href="ai-companions" class="dropdown-link">
                                 <i class="fas fa-robot"></i>
                                 <span>AI Companions</span>
                             </a></li>
@@ -272,7 +272,7 @@
                         <span class="feature-tag">Content Rating</span>
                         <span class="feature-tag">WL Rewards</span>
                     </div>
-                    <a href="telegram-bots.html" class="ecosystem-btn neon-button">
+                    <a href="telegram-bots" class="ecosystem-btn neon-button">
                         EXPLORE BOTS
                         <i class="fas fa-arrow-right"></i>
                     </a>
@@ -306,7 +306,7 @@
                         <span class="feature-tag">Character Lore</span>
                         <span class="feature-tag">Nectar AI Powered</span>
                     </div>
-                    <a href="ai-companions.html" class="ecosystem-btn neon-button">
+                    <a href="ai-companions" class="ecosystem-btn neon-button">
                         MEET YOUR BUDDY
                         <i class="fas fa-arrow-right"></i>
                     </a>

--- a/telegram-bots.html
+++ b/telegram-bots.html
@@ -24,19 +24,19 @@
     <!-- Header -->
     <header class="main-header">
         <div class="header-container">
-            <a href="index.html" class="logo neon-text">
+            <a href="/" class="logo neon-text">
                 <img src="images/mega-buddies-logo.png" alt="Mega Buddies">
                 MEGA BUDDIES
             </a>
             
             <nav class="main-nav">
                 <ul class="nav-list">
-                    <li class="nav-item"><a href="index.html#about" class="nav-link">ABOUT</a></li>
-                    <li class="nav-item"><a href="index.html#manifesto" class="nav-link">MANIFESTO</a></li>
+                    <li class="nav-item"><a href="/#about" class="nav-link">ABOUT</a></li>
+                    <li class="nav-item"><a href="/#manifesto" class="nav-link">MANIFESTO</a></li>
                     <li class="nav-item dropdown active">
-                        <a href="index.html#ecosystem" class="nav-link dropdown-toggle"><span>ECOSYSTEM</span><span class="dropdown-arrow">▼</span></a>
+                        <a href="/#ecosystem" class="nav-link dropdown-toggle"><span>ECOSYSTEM</span><span class="dropdown-arrow">▼</span></a>
                         <ul class="dropdown-menu">
-                            <li><a href="telegram-bots.html" class="dropdown-link active">
+                            <li><a href="telegram-bots" class="dropdown-link active">
                                 <i class="fab fa-telegram"></i>
                                 <span>Telegram Bots</span>
                             </a></li>
@@ -44,7 +44,7 @@
                                 <i class="fas fa-trophy"></i>
                                 <span>Zealy Quests</span>
                             </a></li>
-                            <li><a href="ai-companions.html" class="dropdown-link">
+                            <li><a href="ai-companions" class="dropdown-link">
                                 <i class="fas fa-robot"></i>
                                 <span>AI Companions</span>
                             </a></li>
@@ -55,9 +55,9 @@
                             </span></li>
                         </ul>
                     </li>
-                    <li class="nav-item"><a href="index.html#collection" class="nav-link">COLLECTION</a></li>
-                    <li class="nav-item"><a href="index.html#roadmap" class="nav-link">ROADMAP</a></li>
-                    <li class="nav-item"><a href="index.html#community" class="nav-link">COMMUNITY</a></li>
+                    <li class="nav-item"><a href="/#collection" class="nav-link">COLLECTION</a></li>
+                    <li class="nav-item"><a href="/#roadmap" class="nav-link">ROADMAP</a></li>
+                    <li class="nav-item"><a href="/#community" class="nav-link">COMMUNITY</a></li>
                     <li class="nav-item"><a href="https://buddyrunner.fun" target="_blank" class="nav-link external-link">
                         BUDDY RUNNER
                         <i class="fas fa-external-link-alt"></i>
@@ -86,9 +86,9 @@
         <div class="container">
             <div class="page-hero-content">
                 <div class="breadcrumbs">
-                    <a href="index.html">HOME</a>
+                    <a href="/">HOME</a>
                     <span>/</span>
-                    <a href="index.html#ecosystem">ECOSYSTEM</a>
+                    <a href="/#ecosystem">ECOSYSTEM</a>
                     <span>/</span>
                     <span class="current">TELEGRAM BOTS</span>
                 </div>
@@ -346,7 +346,7 @@
     <!-- Back to Ecosystem -->
     <section class="back-section">
         <div class="container">
-            <a href="index.html#ecosystem" class="back-btn neon-button">
+            <a href="/#ecosystem" class="back-btn neon-button">
                 <i class="fas fa-arrow-left"></i>
                 BACK TO ECOSYSTEM
             </a>
@@ -371,9 +371,9 @@
                 <div class="footer-nav-section">
                     <h3 class="footer-nav-title">Ecosystem</h3>
                     <ul class="footer-nav-links">
-                        <li class="footer-nav-link"><a href="telegram-bots.html">Telegram Bots</a></li>
+                        <li class="footer-nav-link"><a href="telegram-bots">Telegram Bots</a></li>
                         <li class="footer-nav-link"><a href="https://zealy.io/cw/megabuddies/questboard/" target="_blank">Zealy Quests</a></li>
-                        <li class="footer-nav-link"><a href="ai-companions.html">AI Companions</a></li>
+                        <li class="footer-nav-link"><a href="ai-companions">AI Companions</a></li>
                         <li class="footer-nav-link"><a href="https://buddyrunner.fun" target="_blank">Buddy Runner</a></li>
                         <li class="footer-nav-link"><span class="planned">Leaderboard (Planned)</span></li>
                     </ul>


### PR DESCRIPTION
Remove `.html` extensions from URLs and update internal links for modern, clean URLs.

---
<a href="https://cursor.com/background-agent?bcId=bc-0907523c-a1d4-4719-8b69-f27f0ba1eaca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0907523c-a1d4-4719-8b69-f27f0ba1eaca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

