### PR TITLE
Investigate 404 errors on megabuddies.fun

### DIFF
--- a/.htaccess.backup
+++ b/.htaccess.backup
@@ -1,3 +1,5 @@
+# Backup of improved .htaccess configuration
+# Copy this to .htaccess if needed
 
 # Enable CORS headers
 <IfModule mod_headers.c>

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,99 @@
+# Mega Buddies - 404 Error Troubleshooting Guide
+
+## Problem
+The URLs `/ai-companions` and `/telegram-bots` are returning 404 errors, even though the corresponding HTML files exist.
+
+## Root Cause Analysis
+The issue is likely related to URL rewriting configuration on the server. The website uses clean URLs (without .html extensions) but the server may not be properly configured to handle them.
+
+## Solutions Applied
+
+### 1. Improved .htaccess Configuration
+- Enhanced URL rewriting rules for better compatibility
+- Added specific fallback rules for main pages
+- Added support for servers without mod_rewrite
+
+### 2. PHP Router Fallback
+- Created `router.php` as a backup solution
+- Can be used if .htaccess rewriting doesn't work
+
+### 3. Server Testing
+- Created `test-server.html` to diagnose server configuration
+
+## Possible Server Issues
+
+### A. mod_rewrite Not Enabled
+**Symptoms:** Clean URLs return 404 errors
+**Solution:** Contact hosting provider to enable mod_rewrite
+
+### B. .htaccess Not Allowed
+**Symptoms:** All .htaccess rules ignored
+**Solution:** Server admin needs to set `AllowOverride All` in Apache config
+
+### C. File Permissions
+**Symptoms:** Intermittent 404 errors
+**Solution:** Ensure files have correct permissions (644 for files, 755 for directories)
+
+## Quick Fixes to Try
+
+### Option 1: Test Current Configuration
+1. Upload all files to server
+2. Visit `/test-server.html` to diagnose issues
+3. Check if direct `.html` URLs work
+
+### Option 2: Use PHP Router (if .htaccess fails)
+1. Rename `index.html` to `index.php`
+2. Add this to the top of `index.php`:
+   ```php
+   <?php include 'router.php'; ?>
+   ```
+
+### Option 3: Manual Redirects
+If all else fails, create these files:
+
+**ai-companions/index.html:**
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="refresh" content="0; url=../ai-companions.html">
+    <title>Redirecting...</title>
+</head>
+<body>
+    <p>Redirecting to <a href="../ai-companions.html">AI Companions</a>...</p>
+</body>
+</html>
+```
+
+**telegram-bots/index.html:**
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="refresh" content="0; url=../telegram-bots.html">
+    <title>Redirecting...</title>
+</head>
+<body>
+    <p>Redirecting to <a href="../telegram-bots.html">Telegram Bots</a>...</p>
+</body>
+</html>
+```
+
+## Verification Steps
+1. Test direct HTML URLs: `/ai-companions.html`, `/telegram-bots.html`
+2. Test clean URLs: `/ai-companions`, `/telegram-bots`
+3. Check server error logs for specific error messages
+4. Verify file permissions and server configuration
+
+## Files Modified/Created
+- `.htaccess` - Improved URL rewriting rules
+- `router.php` - PHP fallback router
+- `test-server.html` - Server configuration tester
+- `.htaccess.backup` - Backup configuration
+- `TROUBLESHOOTING.md` - This guide
+
+## Contact Information
+If issues persist, contact your hosting provider with these details:
+- mod_rewrite needs to be enabled
+- AllowOverride All needs to be set for the domain
+- File permissions should be 644 for files, 755 for directories

--- a/ai-companions/index.html
+++ b/ai-companions/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=../ai-companions.html">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Companions - Mega Buddies</title>
+    <link rel="canonical" href="../ai-companions.html">
+</head>
+<body>
+    <script>
+        // Immediate redirect
+        window.location.replace('../ai-companions.html');
+    </script>
+    <noscript>
+        <p>Redirecting to <a href="../ai-companions.html">AI Companions</a>...</p>
+        <meta http-equiv="refresh" content="0; url=../ai-companions.html">
+    </noscript>
+</body>
+</html>

--- a/router.php
+++ b/router.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Fallback router for Mega Buddies website
+ * This file can be used if .htaccess URL rewriting is not working
+ */
+
+// Get the requested URI
+$request_uri = $_SERVER['REQUEST_URI'];
+$request_path = parse_url($request_uri, PHP_URL_PATH);
+
+// Remove leading slash
+$path = ltrim($request_path, '/');
+
+// Define routes
+$routes = [
+    'ai-companions' => 'ai-companions.html',
+    'telegram-bots' => 'telegram-bots.html',
+    '' => 'index.html',
+    'index' => 'index.html'
+];
+
+// Check if route exists
+if (array_key_exists($path, $routes)) {
+    $file = $routes[$path];
+    
+    // Check if file exists
+    if (file_exists($file)) {
+        // Set proper content type
+        header('Content-Type: text/html; charset=UTF-8');
+        
+        // Include the HTML file
+        include $file;
+        exit;
+    }
+}
+
+// If no route found, show 404
+http_response_code(404);
+if (file_exists('404.html')) {
+    include '404.html';
+} else {
+    echo '<!DOCTYPE html>
+<html>
+<head><title>404 Not Found</title></head>
+<body>
+<h1>404 Not Found</h1>
+<p>The requested page could not be found.</p>
+<a href="/">Return to Home</a>
+</body>
+</html>';
+}
+?>

--- a/telegram-bots/index.html
+++ b/telegram-bots/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=../telegram-bots.html">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Telegram Bots - Mega Buddies</title>
+    <link rel="canonical" href="../telegram-bots.html">
+</head>
+<body>
+    <script>
+        // Immediate redirect
+        window.location.replace('../telegram-bots.html');
+    </script>
+    <noscript>
+        <p>Redirecting to <a href="../telegram-bots.html">Telegram Bots</a>...</p>
+        <meta http-equiv="refresh" content="0; url=../telegram-bots.html">
+    </noscript>
+</body>
+</html>


### PR DESCRIPTION
Implement multi-layered URL rewriting and fallback solutions to resolve 404 errors for clean URLs like `/ai-companions` and `/telegram-bots`.

The existing `.htaccess` configuration was insufficient for all server environments, causing 404s for clean URLs. This PR provides a more robust `.htaccess`, a PHP-based router, and directory-based HTML redirects to ensure the pages are accessible regardless of server `mod_rewrite` or `AllowOverride` settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-81898131-347b-4900-ab94-ba8f98e38939">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81898131-347b-4900-ab94-ba8f98e38939">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

