### PR TITLE
Fix Avon twitter preview indentation

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -204,7 +204,7 @@
   }
   
   .partnership-description {
-    margin: 10px 0 5px 0 !important;
+    margin: 10px 0 3px 0 !important;
     font-size: 14px !important;
     line-height: 1.4 !important;
     color: var(--text-color) !important;
@@ -213,8 +213,8 @@
   
   /* Исправление позиции Twitter embed */
   .twitter-embed-container {
-    margin-top: 5px !important;
-    padding-top: 3px !important;
+    margin-top: 3px !important;
+    padding-top: 0px !important;
     width: 100% !important;
     overflow: visible !important;
     position: relative !important;

--- a/css/style.css
+++ b/css/style.css
@@ -2758,9 +2758,14 @@ body {
     color: var(--text-color);
     opacity: 0.9;
     line-height: 1.6;
-    margin-bottom: 20px;
+    margin-bottom: 15px;
     font-size: 14px;
-    flex-grow: 1;
+    flex-grow: 0;
+}
+
+.partnership-card .twitter-embed-container {
+    margin: 5px 0 0 0;
+    flex-grow: 0;
 }
 
 
@@ -2809,11 +2814,11 @@ body {
 }
 
 .twitter-embed-container {
-    margin: 20px 0;
-    flex-grow: 1;
+    margin: 10px 0;
+    flex-grow: 0;
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: flex-start;
 }
 
 .twitter-embed-container .twitter-tweet {
@@ -3330,12 +3335,7 @@ body {
     letter-spacing: 1px;
 }
 
-.twitter-embed-container {
-    display: flex;
-    justify-content: center;
-    margin: 0 auto;
-    max-width: 600px;
-}
+/* Duplicate .twitter-embed-container definition removed - using the one above with proper spacing */
 
 .twitter-embed-container .twitter-tweet {
     margin: 0 !important;


### PR DESCRIPTION
Fix large spacing around Twitter embed previews in partnership cards by adjusting margins and removing duplicate CSS.

---
<a href="https://cursor.com/background-agent?bcId=bc-26c7f4d3-0d18-44b3-a82c-82f5618d5cc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-26c7f4d3-0d18-44b3-a82c-82f5618d5cc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

